### PR TITLE
Use minimum amount of open connections

### DIFF
--- a/client/src/main/java/com/king/platform/net/http/netty/pool/ServerPool.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/pool/ServerPool.java
@@ -6,22 +6,24 @@
 package com.king.platform.net.http.netty.pool;
 
 
-import com.king.platform.net.http.netty.ServerInfo;
-import com.king.platform.net.http.netty.metric.MetricCallback;
-import com.king.platform.net.http.netty.util.TimeProvider;
+import static org.slf4j.LoggerFactory.getLogger;
 import io.netty.channel.Channel;
-import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.slf4j.LoggerFactory.getLogger;
+import org.slf4j.Logger;
+
+import com.king.platform.net.http.netty.ServerInfo;
+import com.king.platform.net.http.netty.metric.MetricCallback;
+import com.king.platform.net.http.netty.util.TimeProvider;
 
 public class ServerPool {
 	private final Logger logger = getLogger(getClass());
@@ -30,7 +32,7 @@ public class ServerPool {
 	private final TimeUnit ttlTimeUnit;
 
 	private final AtomicInteger idGenerator = new AtomicInteger();
-	private final ConcurrentLinkedQueue<PooledChannel> pooledChannels = new ConcurrentLinkedQueue<>();
+	private final ConcurrentLinkedDeque<PooledChannel> pooledChannels = new ConcurrentLinkedDeque<>();
 	private final ConcurrentHashMap<Channel, PooledChannel> channelsMap = new ConcurrentHashMap<>();
 	private final TimeProvider timeProvider;
 	private final MetricCallback metricCallback;
@@ -106,7 +108,7 @@ public class ServerPool {
 
 		lastOfferedConnectionTime = timeProvider.currentTimeInMillis();
 		pooledChannel.lastUsedTimeStamp = timeProvider.currentTimeInMillis();
-		pooledChannels.offer(pooledChannel);
+		pooledChannels.addFirst(pooledChannel);
 	}
 
 	public void discard(Channel channel) {

--- a/client/src/test/java/com/king/platform/net/http/netty/pool/PoolingChannelPoolTest.java
+++ b/client/src/test/java/com/king/platform/net/http/netty/pool/PoolingChannelPoolTest.java
@@ -119,8 +119,8 @@ public class PoolingChannelPoolTest {
 
 		Channel fetchedChannel1 = poolingChannelPool.get(serverInfo);
 		Channel fetchedChannel2 = poolingChannelPool.get(serverInfo);
-		assertSame(channel1, fetchedChannel1);
-		assertSame(fetchedChannel2, channel2);
+		assertSame(channel2, fetchedChannel1);
+		assertSame(channel1, fetchedChannel2);
 
 		assertEquals(0, poolingChannelPool.getPoolSize(serverInfo));
 	}


### PR DESCRIPTION
If server's load average increases for a short period of time, the number of connections from the client may increase considerably (e.g. from 200 to 900).  After load average returns to normal (and using current queue structure) the client will continue using the 900 connections even though only 200 are required. Even if you put a 10 seconds read timeout from the server, it won't be able to close those unnecessary connections because the queue takes care that all 900 are actually used.
