### PR TITLE
Expose more info about HTTP response & convenience methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ hs_err_pid*
 .gradle
 build
 build/*
-
+**/out
 # Idea
 .idea
 *.iml

--- a/client/src/main/java/com/king/platform/net/http/HttpClient.java
+++ b/client/src/main/java/com/king/platform/net/http/HttpClient.java
@@ -38,6 +38,15 @@ public interface HttpClient {
 	boolean isStarted();
 
 	/**
+	 * Create reusable builder for http requests. The client has to be started before this method is called.
+	 *
+	 * @param httpMethod Http method to use
+	 * @param uri Http uri to call
+	 * @return The reusable {@link HttpClientRequestBuilder}
+	 */
+	HttpClientRequestBuilder create(HttpMethod httpMethod, String uri);
+
+	/**
 	 * Create reusable builder for http get requests. The client has to be started before this method is called.
 	 *
 	 * @param uri Http uri to call

--- a/client/src/main/java/com/king/platform/net/http/HttpMethod.java
+++ b/client/src/main/java/com/king/platform/net/http/HttpMethod.java
@@ -1,0 +1,52 @@
+package com.king.platform.net.http;
+
+public enum HttpMethod {
+
+	/**
+	 * The GET method means retrieve whatever information (in the form of an entity) is identified
+	 * by the Request-URI.  If the Request-URI refers to a data-producing process, it is the
+	 * produced data which shall be returned as the entity in the response and not the source text
+	 * of the process, unless that text happens to be the output of the process.
+	 */
+	GET,
+
+	/**
+	 * The POST method is used to request that the origin server accept the entity enclosed in the
+	 * request as a new subordinate of the resource identified by the Request-URI in the
+	 * Request-Line.
+	 */
+	POST,
+
+	/**
+	 * The PUT method requests that the enclosed entity be stored under the supplied Request-URI.
+	 */
+	PUT,
+
+	/**
+	 * The DELETE method requests that the origin server delete the resource identified by the
+	 * Request-URI.
+	 */
+	DELETE,
+
+	/**
+	 * The HEAD method is identical to GET except that the server MUST NOT return a message-body
+	 * in the response.
+	 */
+	HEAD,
+
+	/**
+	 * The OPTIONS method represents a request for information about the communication options
+	 * available on the request/response chain identified by the Request-URI. This method allows
+	 * the client to determine the options and/or requirements associated with a resource, or the
+	 * capabilities of a server, without implying a resource action or initiating a resource
+	 * retrieval.
+	 */
+	OPTIONS,
+
+	/**
+	 * The TRACE method is used to invoke a remote, application-layer loop- back of the request
+	 * message.
+	 */
+	TRACE
+
+}

--- a/client/src/main/java/com/king/platform/net/http/HttpResponse.java
+++ b/client/src/main/java/com/king/platform/net/http/HttpResponse.java
@@ -7,24 +7,38 @@ package com.king.platform.net.http;
 
 
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 
 import java.util.List;
 import java.util.Map;
 
 public class HttpResponse<T> {
-	private Headers headers;
-	private final int statusCode;
+
+	private final HttpVersion httpVersion;
+	private final Headers headers;
+	private final HttpResponseStatus status;
 	private final ResponseBodyConsumer<T> responseBodyConsumer;
 
 
-	public HttpResponse(int statusCode, ResponseBodyConsumer responseBodyConsumer, HttpHeaders httpHeaders) {
-		this.statusCode = statusCode;
+	public HttpResponse(HttpVersion httpVersion, HttpResponseStatus status,
+						ResponseBodyConsumer responseBodyConsumer, HttpHeaders httpHeaders) {
+		this.httpVersion = httpVersion;
+		this.status = status;
 		this.responseBodyConsumer = responseBodyConsumer;
-		headers = new Headers(httpHeaders);
+		this.headers = new Headers(httpHeaders);
+	}
+
+	public String getHttpVersion() {
+		return httpVersion.toString();
 	}
 
 	public int getStatusCode() {
-		return statusCode;
+		return status.code();
+	}
+
+	public String getStatusReason() {
+		return status.reasonPhrase();
 	}
 
 	public T getBody() {

--- a/client/src/main/java/com/king/platform/net/http/netty/NettyHttpClient.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/NettyHttpClient.java
@@ -139,6 +139,13 @@ public class NettyHttpClient implements HttpClient {
 	}
 
 	@Override
+	public HttpClientRequestBuilder create(final com.king.platform.net.http.HttpMethod httpMethod, final String uri) {
+		verifyStarted();
+		return new HttpClientRequestBuilderImpl(httpClientCaller, HttpVersion.HTTP_1_1, NettyHttpMethods.toNettyMethod(httpMethod), uri, confMap,
+			defaultHttpClientCallbackExecutor);
+	}
+
+	@Override
 	public HttpClientRequestBuilder createGet(String uri) {
 		verifyStarted();
 		return new HttpClientRequestBuilderImpl(httpClientCaller, HttpVersion.HTTP_1_1, HttpMethod.GET, uri, confMap, defaultHttpClientCallbackExecutor);

--- a/client/src/main/java/com/king/platform/net/http/netty/NettyHttpMethods.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/NettyHttpMethods.java
@@ -1,0 +1,41 @@
+package com.king.platform.net.http.netty;
+
+import com.king.platform.net.http.HttpMethod;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+final class NettyHttpMethods {
+
+	private static final Map<HttpMethod, io.netty.handler.codec.http.HttpMethod> mappings;
+
+	static {
+		mappings = new EnumMap<>(HttpMethod.class);
+		mappings.put(HttpMethod.GET, io.netty.handler.codec.http.HttpMethod.GET);
+		mappings.put(HttpMethod.POST, io.netty.handler.codec.http.HttpMethod.POST);
+		mappings.put(HttpMethod.PUT, io.netty.handler.codec.http.HttpMethod.PUT);
+		mappings.put(HttpMethod.DELETE, io.netty.handler.codec.http.HttpMethod.DELETE);
+		mappings.put(HttpMethod.HEAD, io.netty.handler.codec.http.HttpMethod.HEAD);
+		mappings.put(HttpMethod.OPTIONS, io.netty.handler.codec.http.HttpMethod.OPTIONS);
+		mappings.put(HttpMethod.TRACE, io.netty.handler.codec.http.HttpMethod.TRACE);
+
+		verifyIntegrity();
+	}
+
+	private NettyHttpMethods() {
+	}
+
+	static io.netty.handler.codec.http.HttpMethod toNettyMethod(final HttpMethod httpMethod) {
+		return mappings.get(httpMethod);
+	}
+
+	private static void verifyIntegrity() {
+		for (final HttpMethod httpMethod : HttpMethod.values()) {
+			if (!mappings.containsKey(httpMethod)) {
+				throw new IllegalStateException(
+					"Missing mapping to Netty HttpMethod for " + httpMethod.getClass().getName() + "." + httpMethod);
+			}
+		}
+	}
+
+}

--- a/client/src/main/java/com/king/platform/net/http/netty/requestbuilder/BuiltNettyClientRequest.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/requestbuilder/BuiltNettyClientRequest.java
@@ -18,6 +18,7 @@ import com.king.platform.net.http.netty.request.NettyHttpClientRequest;
 import com.king.platform.net.http.util.Param;
 import com.king.platform.net.http.util.UriUtil;
 import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.HttpMethod;
 
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;

--- a/client/src/main/java/com/king/platform/net/http/netty/response/HttpClientResponseHandler.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/response/HttpClientResponseHandler.java
@@ -178,8 +178,8 @@ public class HttpClientResponseHandler implements ResponseHandler {
 		requestEventBus.triggerEvent(Event.onReceivedCompleted, httpResponseStatus, httpHeaders);
 		httpRequestContext.getTimeRecorder().responseBodyCompleted();
 
-		@SuppressWarnings("unchecked") com.king.platform.net.http.HttpResponse httpResponse = new com.king.platform.net.http.HttpResponse(httpResponseStatus
-			.code(), responseBodyConsumer, httpHeaders);
+		@SuppressWarnings("unchecked") com.king.platform.net.http.HttpResponse httpResponse =
+			new com.king.platform.net.http.HttpResponse(httpVersion(httpRequestContext), httpResponseStatus, responseBodyConsumer, httpHeaders);
 
 		requestEventBus.triggerEvent(Event.onHttpResponseDone, httpResponse);
 
@@ -228,6 +228,10 @@ public class HttpClientResponseHandler implements ResponseHandler {
 			requestEventBus.triggerEvent(Event.ERROR, httpRequestContext, e);
 		}
 
+	}
+
+	private static HttpVersion httpVersion(final HttpRequestContext httpRequestContext) {
+		return httpRequestContext.getNettyHttpClientRequest().getNettyRequest().protocolVersion();
 	}
 
 	private boolean incomnpleteReadOfData(HttpRequestContext httpRequestContext) {

--- a/client/src/test/java/com/king/platform/net/http/HttpResponseTest.java
+++ b/client/src/test/java/com/king/platform/net/http/HttpResponseTest.java
@@ -6,6 +6,8 @@
 package com.king.platform.net.http;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import org.junit.Test;
 
 import java.util.AbstractMap;
@@ -13,8 +15,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 @SuppressWarnings("unchecked")
 public class HttpResponseTest {
@@ -25,7 +29,7 @@ public class HttpResponseTest {
 		DefaultHttpHeaders defaultHttpHeaders = new DefaultHttpHeaders();
 		defaultHttpHeaders.add("Accept", "*/*");
 
-		HttpResponse httpResponse = new HttpResponse(200, null, defaultHttpHeaders);
+		HttpResponse httpResponse = new HttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null, defaultHttpHeaders);
 
 		assertEquals("*/*", httpResponse.getHeader("Accept"));
 		assertEquals("*/*", httpResponse.getHeader("ACCEPT"));
@@ -41,7 +45,7 @@ public class HttpResponseTest {
 		defaultHttpHeaders.add("ACCEPT", "*/*");
 		defaultHttpHeaders.add("accept", "*/*");
 
-		HttpResponse httpResponse = new HttpResponse(200, null, defaultHttpHeaders);
+		HttpResponse httpResponse = new HttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null, defaultHttpHeaders);
 		List<String> headers = httpResponse.getHeaders("accept");
 		assertEquals(3, headers.size());
 		for (String header : headers) {
@@ -51,7 +55,7 @@ public class HttpResponseTest {
 
 	@Test
 	public void getUnknownHeaderShouldReturnNull() throws Exception {
-		HttpResponse httpResponse = new HttpResponse(200, null, new DefaultHttpHeaders());
+		HttpResponse httpResponse = new HttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null, new DefaultHttpHeaders());
 		String value = httpResponse.getHeader("undefined");
 		assertNull(value);
 	}
@@ -63,12 +67,25 @@ public class HttpResponseTest {
 		defaultHttpHeaders.add("ACCEPT", "*/*");
 		defaultHttpHeaders.add("accept", "*/*");
 
-		HttpResponse httpResponse = new HttpResponse(200, null, defaultHttpHeaders);
+		HttpResponse httpResponse = new HttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null, defaultHttpHeaders);
 		List<Map.Entry<String, String>> allHeaders = httpResponse.getAllHeaders();
 		assertEquals(3, allHeaders.size());
 		for (Map.Entry<String, String> entry : allHeaders) {
 			assertEquals("*/*", entry.getValue());
 		}
 
+	}
+
+	@Test
+	public void getStatus() {
+		final HttpResponse httpResponse = new HttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null, new DefaultHttpHeaders());
+		assertThat(httpResponse.getStatusCode(), is(HttpResponseStatus.OK.code()));
+		assertThat(httpResponse.getStatusReason(), is(HttpResponseStatus.OK.reasonPhrase()));
+	}
+
+	@Test
+	public void getHttpVersion() {
+		final HttpResponse httpResponse = new HttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null, new DefaultHttpHeaders());
+		assertThat(httpResponse.getHttpVersion(), is(HttpVersion.HTTP_1_1.toString()));
 	}
 }


### PR DESCRIPTION
This pull request is to:

* Expose all the status line information in HttpResponse.
* Add a request creation method in HttpClient that takes the HTTP method as parameter, to ease usage in places that might need to create many kind of requests.