### PR TITLE
Fix calls to URI with underscore

### DIFF
--- a/client/src/test/java/com/king/platform/net/http/netty/ServerInfoTest.java
+++ b/client/src/test/java/com/king/platform/net/http/netty/ServerInfoTest.java
@@ -7,11 +7,9 @@ package com.king.platform.net.http.netty;
 
 import org.junit.Test;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ServerInfoTest {
 
@@ -21,8 +19,16 @@ public class ServerInfoTest {
 		assertEquals("someserver", serverInfo.getHost());
 		assertEquals("http", serverInfo.getScheme());
 		assertEquals(80, serverInfo.getPort());
-		assertEquals(false, serverInfo.isSecure());
+		assertFalse(serverInfo.isSecure());
+	}
 
+	@Test
+	public void buildFromHttpUriWithDefaultPortAndUnderscoreHostname() throws Exception {
+		ServerInfo serverInfo = ServerInfo.buildFromUri("http://some_server/foo/bar");
+		assertEquals("some_server", serverInfo.getHost());
+		assertEquals("http", serverInfo.getScheme());
+		assertEquals(80, serverInfo.getPort());
+		assertFalse(serverInfo.isSecure());
 	}
 
 	@Test
@@ -31,7 +37,16 @@ public class ServerInfoTest {
 		assertEquals("someserver", serverInfo.getHost());
 		assertEquals("https", serverInfo.getScheme());
 		assertEquals(443, serverInfo.getPort());
-		assertEquals(true, serverInfo.isSecure());
+		assertTrue(serverInfo.isSecure());
+	}
+
+	@Test
+	public void buildFromHttpsUriWithDefaultPortAndUnderscoreHostname() throws Exception {
+		ServerInfo serverInfo = ServerInfo.buildFromUri("https://some_server/foo/bar");
+		assertEquals("some_server", serverInfo.getHost());
+		assertEquals("https", serverInfo.getScheme());
+		assertEquals(443, serverInfo.getPort());
+		assertTrue(serverInfo.isSecure());
 	}
 
 	@Test
@@ -40,8 +55,16 @@ public class ServerInfoTest {
 		assertEquals("someserver", serverInfo.getHost());
 		assertEquals("http", serverInfo.getScheme());
 		assertEquals(8081, serverInfo.getPort());
-		assertEquals(false, serverInfo.isSecure());
+		assertFalse(serverInfo.isSecure());
+	}
 
+	@Test
+	public void buildFromHttpUriWithSpecificPortAndUnderscoreHostname() throws Exception {
+		ServerInfo serverInfo = ServerInfo.buildFromUri("http://some_server:8081/foo/bar");
+		assertEquals("some_server", serverInfo.getHost());
+		assertEquals("http", serverInfo.getScheme());
+		assertEquals(8081, serverInfo.getPort());
+		assertFalse(serverInfo.isSecure());
 	}
 
 	@Test
@@ -53,14 +76,28 @@ public class ServerInfoTest {
 	}
 
 	@Test
+	public void buildFromWebServiceAndUnderscoreHostname() throws Exception {
+		ServerInfo serverInfo = ServerInfo.buildFromUri("ws://some_server:8081/foo/bar");
+		assertEquals("some_server", serverInfo.getHost());
+		assertEquals("ws", serverInfo.getScheme());
+		assertEquals(8081, serverInfo.getPort());
+	}
+
+	@Test
 	public void buildFromSecureWebService() throws Exception {
 		ServerInfo serverInfo = ServerInfo.buildFromUri("wss://someserver:8443/foo/bar");
 		assertEquals("someserver", serverInfo.getHost());
 		assertEquals("wss", serverInfo.getScheme());
 		assertEquals(8443, serverInfo.getPort());
-		assertEquals(true, serverInfo.isSecure());
-
+		assertTrue(serverInfo.isSecure());
 	}
 
-
+	@Test
+	public void buildFromSecureWebServiceAndUnderscoreHostname() throws Exception {
+		ServerInfo serverInfo = ServerInfo.buildFromUri("wss://some_server:8443/foo/bar");
+		assertEquals("some_server", serverInfo.getHost());
+		assertEquals("wss", serverInfo.getScheme());
+		assertEquals(8443, serverInfo.getPort());
+		assertTrue(serverInfo.isSecure());
+	}
 }


### PR DESCRIPTION
## Problem

When a url contains an underscore `_` symbol, the `URI` class sets the host to `null`. You can read more [here](https://bugs.openjdk.java.net/browse/JDK-8221675).

## Solution

According to this [Stack Overflow thread](https://stackoverflow.com/questions/28568188/java-net-uri-get-host-with-underscores), the only temporary solution goes by patching the `URI` class via metaprogramming.

## Implementation details

Fortunately, all the logic is contained in one class, the `ServerInfo`. I tried to apply the change in the most isolated and non-intrusive way I could. I also added new tests for the underscore uses cases and I made sure that the old ones are still passing.
