### PR TITLE
Don't overflow on ByteAggregator creation

### DIFF
--- a/client/src/main/java/com/king/platform/net/http/ByteAggregator.java
+++ b/client/src/main/java/com/king/platform/net/http/ByteAggregator.java
@@ -16,14 +16,22 @@ public class ByteAggregator {
 	private final ByteArrayOutputStream byteArrayOutputStream;
 	private final WritableByteChannel channel;
 
-	public ByteAggregator(long contentLength) {
+	public ByteAggregator(int contentLength) {
 		if (contentLength < 0) {
 			contentLength = 1024;
 		}
 
-		byteArrayOutputStream = new ByteArrayOutputStream((int) contentLength);
+		byteArrayOutputStream = new ByteArrayOutputStream(contentLength);
 		channel = Channels.newChannel(byteArrayOutputStream);
 
+	}
+
+	/**
+	 * @deprecated Use the {@link ByteAggregator#ByteAggregator(int)} constructor instead
+	 */
+	@Deprecated
+	public ByteAggregator(long contentLength) {
+		this(Math.toIntExact(contentLength));
 	}
 
 	public void write(ByteBuffer buffer) throws IOException {

--- a/client/src/test/java/com/king/platform/net/http/ByteAggregatorTest.java
+++ b/client/src/test/java/com/king/platform/net/http/ByteAggregatorTest.java
@@ -8,12 +8,20 @@ package com.king.platform.net.http;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ByteAggregatorTest {
 
 	@Test
-	public void constructorShouldNotThrowExceptionWhenSuppliedWithNegativeLength() throws Exception {
-		assertNotNull(new ByteAggregator(-100));
+	public void constructorShouldNotThrowExceptionWhenSuppliedWithNegativeLength() {
+		assertDoesNotThrow(() -> new ByteAggregator(-100));
+	}
+
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void constructorShouldThrowExceptionWhenSuppliedWithABigLongNumber() {
+		assertThrows(ArithmeticException.class, () -> new ByteAggregator((long) Integer.MAX_VALUE + 3));
 	}
 }


### PR DESCRIPTION
Use `int` for the ByteAggregator to not overflow when creating the underlying ByteArrayOutputStream.

Bonus: Fix warnings on the `ByteAggregatorTest`