### PR TITLE
Parsing of charset in Content-Type header fails with multiple parameters

### DIFF
--- a/client/src/main/java/com/king/platform/net/http/netty/response/HttpClientResponseHandler.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/response/HttpClientResponseHandler.java
@@ -105,7 +105,8 @@ public class HttpClientResponseHandler implements ResponseHandler {
 				String contentLength = httpHeaders.get(HttpHeaderNames.CONTENT_LENGTH);
 
 				String contentType = httpHeaders.get(HttpHeaderNames.CONTENT_TYPE);
-				String charset = StringUtil.substringAfter(contentType, '=', true);
+
+				String charset = StringUtil.substringKeyValue("charset", contentType,';', true);
 				if (charset == null) {
 					charset = StandardCharsets.ISO_8859_1.name();
 				}

--- a/client/src/main/java/com/king/platform/net/http/netty/util/StringUtil.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/util/StringUtil.java
@@ -48,4 +48,63 @@ public class StringUtil {
 	private static boolean isQuoteMark(char c) {
 		return c == '\"' || c == '\'';
 	}
+
+
+	public static String substringKeyValue(String keyToFind, String src, char delimiter, boolean stripQuoteMarks) {
+		if (keyToFind == null) {
+			return null;
+		}
+
+		if (src ==  null) {
+			return null;
+		}
+
+		int srcLength = src.length();
+
+		int startPosOfKey = src.indexOf(keyToFind);
+		if (startPosOfKey == -1) {
+			return null;
+		}
+
+		int endPosOfKey = startPosOfKey + keyToFind.length();
+
+		while(endPosOfKey != srcLength && src.charAt(endPosOfKey) == ' ') {  //trim whitespace between key and delimiter
+			endPosOfKey++;
+		}
+
+		if (endPosOfKey == srcLength) { //no key was found for this value
+			return  "";
+		}
+
+		if (src.charAt(endPosOfKey) != '=') {
+			return "";
+		}
+
+		int startOfValue = endPosOfKey + 1;
+
+		while(src.charAt(startOfValue) == ' ') {  //trim whitespace between delimiter and value
+			startOfValue++;
+		}
+
+		int endOfValue = src.indexOf(delimiter, startOfValue);
+		if (endOfValue == -1) {
+
+			endOfValue = srcLength;
+		}
+
+
+		while(src.charAt(endOfValue-1) == ' ') { //trim whitespace between value and next delimiter
+			endOfValue--;
+		}
+
+
+		if (stripQuoteMarks && isQuoteMark(src.charAt(startOfValue))) {
+			startOfValue++;
+			endOfValue--;
+		}
+
+		return src.substring(startOfValue, endOfValue);
+
+
+	}
 }

--- a/client/src/test/java/com/king/platform/net/http/netty/response/HttpClientResponseHandlerTest.java
+++ b/client/src/test/java/com/king/platform/net/http/netty/response/HttpClientResponseHandlerTest.java
@@ -1,0 +1,83 @@
+package com.king.platform.net.http.netty.response;
+
+import com.king.platform.net.http.ResponseBodyConsumer;
+import com.king.platform.net.http.netty.BaseHttpRequestHandler;
+import com.king.platform.net.http.netty.HttpRequestContext;
+import com.king.platform.net.http.netty.eventbus.RequestEventBus;
+import com.king.platform.net.http.netty.metric.TimeStampRecorder;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.*;
+import io.netty.util.Attribute;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.mockito.Mockito.*;
+
+public class HttpClientResponseHandlerTest {
+
+    /**
+     * EBNF spec of Content-Type header:
+     *
+     *  media-type = type "/" subtype *( OWS ";" OWS parameter )
+     *  type       = token
+     *  subtype    = token
+     *  parameter      = token "=" ( token / quoted-string )
+     *
+     *  See  <a href="https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.5">RFC7231 - Section 3.1.1.5</a>
+     */
+    @ParameterizedTest
+    @CsvSource(value = {
+            "text/plain; charset=utf-8:text/plain:utf-8",
+            "text/plain;charset=ISO-8851-1:text/plain:ISO-8851-1",
+            "text/plain;charset=ISO-8851-1:text/plain:ISO-8851-1",
+            "text/plain;charset=\"ISO-8851-1\":text/plain:ISO-8851-1",
+            "text/plain; version=0.0.4; charset=utf-8:text/plain:utf-8"
+    }, delimiter = ':')
+    public void handle_directives_in_ContentType(String contentTypeHeader, String contentType, String charset) throws Exception {
+
+        HttpRedirector mockRedirector = mock(HttpRedirector.class);
+        HttpClientResponseHandler handler = new HttpClientResponseHandler(mockRedirector);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        Channel mockChannel = mock(Channel.class);
+        Attribute<HttpRequestContext> mockCtxAttr = mock(Attribute.class);
+        HttpRequestContext mockRequestCtx = mock(HttpRequestContext.class);
+        Attribute<Boolean> mockErrorAttr = mock(Attribute.class);
+        NettyHttpClientResponse mockNettyHttpClientResp = mock(NettyHttpClientResponse.class);
+        RequestEventBus mockRequestEventBus = mock(RequestEventBus.class);
+        ResponseBodyConsumer mockRespBodyConsumer = mock(ResponseBodyConsumer.class);
+
+        when(ctx.channel()).thenReturn(mockChannel);
+
+        when(mockChannel.attr(HttpRequestContext.HTTP_REQUEST_ATTRIBUTE_KEY)).thenReturn(mockCtxAttr);
+        when(mockCtxAttr.get()).thenReturn(mockRequestCtx);
+
+        when(mockChannel.attr(BaseHttpRequestHandler.HTTP_CLIENT_HANDLER_TRIGGERED_ERROR)).thenReturn(mockErrorAttr);
+        when(mockErrorAttr.get()).thenReturn(false);
+
+        when(mockRequestCtx.hasCompletedContent()).thenReturn(false);
+
+        when(mockRequestCtx.getNettyHttpClientResponse()).thenReturn(mockNettyHttpClientResp);
+        when(mockNettyHttpClientResp.getRequestEventBus()).thenReturn(mockRequestEventBus);
+        when(mockNettyHttpClientResp.getResponseBodyConsumer()).thenReturn(mockRespBodyConsumer);
+
+        HttpResponse msg = mock(HttpResponse.class);
+        DecoderResult decodeRes = mock(DecoderResult.class);
+        when(msg.decoderResult()).thenReturn(decodeRes);
+        when(decodeRes.isFailure()).thenReturn(false);
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.CONTENT_TYPE, contentTypeHeader);
+        when(msg.headers()).thenReturn(headers);
+
+        TimeStampRecorder mockTimeRecorder = mock(TimeStampRecorder.class);
+        when(mockRequestCtx.getTimeRecorder()).thenReturn(mockTimeRecorder);
+
+        when(mockRequestCtx.getHttpMethod()).thenReturn(HttpMethod.GET);
+        when(msg.status()).thenReturn(HttpResponseStatus.OK);
+        handler.handleResponse(ctx, msg);
+
+        verify(mockRespBodyConsumer, times(1)).onBodyStart(contentType, charset, 0);
+    }
+}

--- a/client/src/test/java/com/king/platform/net/http/netty/util/StringUtilTest.java
+++ b/client/src/test/java/com/king/platform/net/http/netty/util/StringUtilTest.java
@@ -7,6 +7,8 @@ package com.king.platform.net.http.netty.util;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -49,4 +51,31 @@ public class StringUtilTest {
 
 		assertNull(StringUtil.substringAfter("text/html", '=', false));
 	}
+
+
+	@ParameterizedTest
+	@CsvSource(value = {
+		"text/plain; charset=utf-8:utf-8",
+		"text/plain;charset=ISO-8851-1:ISO-8851-1",
+		"text/plain;charset=ISO-8851-1:ISO-8851-1",
+		"text/plain;charset=\"ISO-8851-1\":ISO-8851-1",
+		"text/plain; version=0.0.4; charset=utf-8:utf-8",
+		"text/plain; charset=utf-8; version=0.0.4:utf-8",
+		"text/plain; version   = 0.0.4   ; charset =  utf-8  :utf-8",
+		"text/plain; charset   = utf-8   ; version =  0.0.4  :utf-8"
+	}, delimiter = ':')
+	void substringKeyValueTest(String input, String expected) {
+		assertEquals(expected, StringUtil.substringKeyValue("charset", input, ';', true));
+	}
+	@Test
+	void substringKeyValueWithMissingValueOrKeyTest() {
+		assertNull(StringUtil.substringKeyValue(null, null, ';', true));
+		assertNull(StringUtil.substringKeyValue(null, "aaa", ';', true));
+		assertNull(StringUtil.substringKeyValue("aaa", null, ';', true));
+		assertNull(StringUtil.substringKeyValue("ddd", "aaa=1;bbb=;ccc", ';', true));
+
+		assertEquals("", StringUtil.substringKeyValue("bbb", "aaa=1;bbb=;ccc", ';', true));
+		assertEquals("", StringUtil.substringKeyValue("ccc", "aaa=1;bbb=;ccc", ';', true));
+	}
+
 }


### PR DESCRIPTION
EBNF spec of Content-Type header:

```
  media-type = type "/" subtype *( OWS ";" OWS parameter )
  type       = token
  subtype    = token
  parameter  = token "=" ( token / quoted-string )
```

See [RFC7231 - Section 3.1.1.5](https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.5)

But this test shows that parsing of
`Content-Type: text/plain; version=0.0.4; charset=utf-8` result in charset `0.0.4; charset=utf-8` instead of the expected `utf-8`.