### PR TITLE
[Breaking change] Removing currentTimeInNanos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,5 +23,5 @@ You generally only need to submit a CLA once, so if you've already submitted
 one (even if it was for a different project), you probably don't need to do it
 again.
 
-[individual CLA]: http://company.king.com/cla-individual
-[corporate CLA]: http://company.king.com/cla-corporate
+[individual CLA]: https://www.king.com/corporate-and-media/compliance/contributor-license-individual
+[corporate CLA]: https://www.king.com/corporate-and-media/compliance/contributor-license-corporate

--- a/client/src/main/java/com/king/platform/net/http/netty/util/SystemTimeProvider.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/util/SystemTimeProvider.java
@@ -12,10 +12,4 @@ public class SystemTimeProvider implements TimeProvider {
 	public long currentTimeInMillis() {
 		return System.currentTimeMillis();
 	}
-
-
-	@Override
-	public long currentTimeInNanos() {
-		return System.nanoTime();
-	}
 }

--- a/client/src/main/java/com/king/platform/net/http/netty/util/TimeProvider.java
+++ b/client/src/main/java/com/king/platform/net/http/netty/util/TimeProvider.java
@@ -8,6 +8,4 @@ package com.king.platform.net.http.netty.util;
 
 public interface TimeProvider {
 	long currentTimeInMillis();
-
-	long currentTimeInNanos();
 }

--- a/client/src/test/java/com/king/platform/net/http/netty/util/TimeProviderForTesting.java
+++ b/client/src/test/java/com/king/platform/net/http/netty/util/TimeProviderForTesting.java
@@ -25,9 +25,4 @@ public class TimeProviderForTesting implements TimeProvider {
 	public long currentTimeInMillis() {
 		return now;
 	}
-
-	@Override
-	public long currentTimeInNanos() {
-		return now * 1000 * 1000;
-	}
 }


### PR DESCRIPTION
Removing the unused method `currentTimeInNanos` on `TimeProvider`, making it sleeker to implement.
The intricacies of `System.nanoTime()` is not really reflected in the interface either, which could be a bit misleading.

I'm also updating the links in the contribution doc to point to the new locations of the CLAs.